### PR TITLE
Test fixed

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@ var readFile = require('fs').readFile;
 var assert = require('assert');
 var exec = require('child_process').exec;
 var join = require('path').join;
+var platform = require('os').platform;
 
 // Test the expected output.
 exec('node .', function(err, stdout, stderr) {
@@ -14,7 +15,7 @@ exec('node .', function(err, stdout, stderr) {
             throw err;
         }
 
-        var expected = exp.split('\r\n');
+        var expected = platform() == 'win32' ? exp.split('\r\n') : exp.split('\n');
         var actual = stdout.split('\n');
 
         for (var i = 0, mx = expected.length; i < mx; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ var readFile = require('fs').readFile;
 var assert = require('assert');
 var exec = require('child_process').exec;
 var join = require('path').join;
-var platform = require('os').platform;
+var os = require('os');
 
 // Test the expected output.
 exec('node .', function(err, stdout, stderr) {
@@ -15,7 +15,7 @@ exec('node .', function(err, stdout, stderr) {
             throw err;
         }
 
-        var expected = platform() == 'win32' ? exp.split('\r\n') : exp.split('\n');
+        var expected = exp.split(os.EOL);
         var actual = stdout.split('\n');
 
         for (var i = 0, mx = expected.length; i < mx; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ exec('node .', function(err, stdout, stderr) {
             throw err;
         }
 
-        var expected = exp.split('\n');
+        var expected = exp.split('\r\n');
         var actual = stdout.split('\n');
 
         for (var i = 0, mx = expected.length; i < mx; i++) {


### PR DESCRIPTION
Was missing a `\r`. Not sure why it broke since last year. Resolves #5.
