### PR TITLE
Configurable fizzbuzz

### DIFF
--- a/fizzbuzz.js
+++ b/fizzbuzz.js
@@ -1,5 +1,5 @@
-module.exports = function fizzbuzz(length) {
-  const outputs = Array.from(
+const fizzbuzz = module.exports = (length)  => (
+  Array.from(
     { length },
     (_, idx) => (++idx % 15 === 0)
       ? 'FizzBuzz'
@@ -9,10 +9,8 @@ module.exports = function fizzbuzz(length) {
           ? 'Buzz'
           : idx
   )
-  outputs.map( val => console.log(val))
-  return outputs
-}
+)
 
 if(require.main === module){
-  module.exports(100)
+  fizzbuzz(100).map( val => console.log(val))
 }

--- a/fizzbuzz.js
+++ b/fizzbuzz.js
@@ -1,13 +1,12 @@
+const operators = {
+  'Fizz': (num) => num % 3 === 0,
+  'Buzz': (num) => num % 5 === 0
+}
+
 const fizzbuzz = module.exports = (length)  => (
   Array.from(
     { length },
-    (_, idx) => (++idx % 15 === 0)
-      ? 'FizzBuzz'
-      : (idx % 3 === 0)
-        ? 'Fizz'
-        : (idx % 5 === 0)
-          ? 'Buzz'
-          : idx
+    (_, idx) => Object.keys(operators).reduce((output, key) => output + ((operators[key](idx+1)) ? key : ''), '') || idx+1
   )
 )
 

--- a/fizzbuzz.js
+++ b/fizzbuzz.js
@@ -1,0 +1,18 @@
+module.exports = function fizzbuzz(length) {
+  const outputs = Array.from(
+    { length },
+    (_, idx) => (++idx % 15 === 0)
+      ? 'FizzBuzz'
+      : (idx % 3 === 0)
+        ? 'Fizz'
+        : (idx % 5 === 0)
+          ? 'Buzz'
+          : idx
+  )
+  outputs.map( val => console.log(val))
+  return outputs
+}
+
+if(require.main === module){
+  module.exports(100)
+}


### PR DESCRIPTION
Use reduce function to make FizzBuzz configurable.  By changing, removing, adding the keys to `operators` the  functionality of the fizzbuzz can be altered without changing the fizzbuzz function 
